### PR TITLE
Use `model_name` in favour of `module_name` if available.

### DIFF
--- a/gargoyle/conditions.py
+++ b/gargoyle/conditions.py
@@ -315,7 +315,11 @@ class ModelConditionSet(ConditionSet):
         return '%s.%s(%s)' % (self.__module__, self.__class__.__name__, self.get_namespace())
 
     def get_namespace(self):
-        return '%s.%s' % (self.model._meta.app_label, self.model._meta.module_name)
+        if hasattr(self.model._meta, 'model_name'):
+            model_name = self.model._meta.model_name
+        else:
+            model_name = self.model._meta.module_name
+        return '%s.%s' % (self.model._meta.app_label, model_name)
 
     def get_group_label(self):
         return self.model._meta.verbose_name.title()


### PR DESCRIPTION
Prevents raising a deprecation warning in Django 1.6+.

https://docs.djangoproject.com/en/1.7/releases/1.6/#module-name-model-meta-attribute
